### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/source/docs/releaseNotes.txt
+++ b/source/docs/releaseNotes.txt
@@ -401,7 +401,7 @@ Missing Features
 	    http://stackoverflow.com/questions/81406/parser-for-c-sharp
 	    mono dmcs/mcs
 	- Change help links to github
-		https://rawgit.com/animatedb/oovaide/master/web/articles/PortionDiagrams.html
+		https://combinatronics.com/animatedb/oovaide/master/web/articles/PortionDiagrams.html
 	- Popularize project
 		- https://github.com/rdp/open-source-how-to-popularize-your-project
 		- http://keywordtool.io/search


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.